### PR TITLE
Fix the location picker on a machine with no weather location

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -98,8 +98,40 @@ Panel {
   // ---------------------------------------------------------------------------
 
   readonly property bool hasLocation: radar ? radar.hasLocation === true : false
-  readonly property real homeLatitude: hasLocation ? radar.location.latitude : 0
-  readonly property real homeLongitude: hasLocation ? radar.location.longitude : 0
+  // Held rather than bound, so an absent coordinate leaves them alone instead
+  // of becoming a real one. `location` is reassigned a moment before
+  // `hasLocation` catches up, and a binding must yield a number — there is no
+  // way to say "unchanged" — so any binding over that gap would place home at
+  // 0,0, off the coast of west Africa. Updated only from values that parse.
+  property real homeLatitude: 0
+  property real homeLongitude: 0
+  // Deliberately not gated on `hasLocation`. That flag is derived from the same
+  // object and settles a moment later, so requiring it here would discard the
+  // one call that carries the coordinates and leave home at 0,0 for good. The
+  // parse below is the only test that matters: it accepts a usable pair and
+  // ignores everything else.
+  function updateHome() {
+    if (!radar || !radar.location) return
+    var la = parseFloat(radar.location.latitude)
+    var lo = parseFloat(radar.location.longitude)
+    if (!isFinite(la) || !isFinite(lo)) return
+
+    homeLatitude = la
+    homeLongitude = lo
+
+    // Recentre here rather than from a change handler on each coordinate. Such
+    // a handler fires between the two writes, on the new latitude beside the
+    // old longitude — a point that never existed, which the map would centre on
+    // and fetch a full round of tiles for before being corrected.
+    if (!panned) recenter()
+  }
+
+  Connections {
+    target: root.radar
+    function onLocationChanged() { root.updateHome() }
+  }
+
+  onRadarChanged: updateHome()
   readonly property string locationName: radar ? radar.locationName : ""
 
   property real viewLatitude: 0
@@ -112,17 +144,20 @@ Panel {
   readonly property int radarSourceZoom: Math.min(zoom, RadarModel.MAX_RADAR_ZOOM)
   readonly property bool radarUpscaled: zoom > RadarModel.MAX_RADAR_ZOOM
 
-  // True while the view still sits on the configured location, so the
-  // "recentre" affordance only appears once panning has actually moved away.
-  readonly property bool centeredOnHome:
-    Math.abs(viewLatitude - homeLatitude) < 0.0001 && Math.abs(viewLongitude - homeLongitude) < 0.0001
-
   function recenter() {
+    // Nothing to centre on before a location exists; recentring on the
+    // placeholder would move the view to 0,0 rather than leave it alone.
+    if (!hasLocation) return
     viewLatitude = homeLatitude
     viewLongitude = homeLongitude
   }
 
-  onHasLocationChanged: if (hasLocation && !panned) recenter()
+  onHasLocationChanged: {
+    // updateHome recentres itself when it lands a usable pair, and when it
+    // does not the coordinates are unusable anyway — so there is nothing to
+    // add here.
+    updateHome()
+  }
   property bool panned: false
 
   // ---------------------------------------------------------------------------
@@ -182,7 +217,15 @@ Panel {
     persistLocation("", null, null)
   }
 
+  // What the last save asked for, so a save that changes nothing can be told
+  // apart from one that does.
+  property real pendingLatitude: NaN
+  property real pendingLongitude: NaN
+
   function persistLocation(name, latitude, longitude) {
+    pendingLatitude = parseFloat(latitude)
+    pendingLongitude = parseFloat(longitude)
+
     if (name && latitude !== null && longitude !== null)
       locationSaveProc.command = ["omarchy-weather-location", "--set", name, latitude + "," + longitude]
     else if (name)
@@ -235,22 +278,28 @@ Panel {
       root.savingLocation = false
       if (exitCode !== 0) return
 
-      // Tell the service to re-read rather than waiting for its file watch.
-      // The first location ever written lands in a directory that did not
-      // exist when that watch was set up, so nothing would announce it.
+      // Clear `panned` before anything can deliver a location, so the order of
+      // what follows cannot decide whether the map recentres.
+      root.panned = false
+
+      // Recentre now only when what was saved is what home already holds —
+      // re-choosing the stored city, where identical coordinates mean no
+      // property changes and so nothing else would fire. Doing it
+      // unconditionally would snap the map to the previous city first on a
+      // move, and onto the city just removed on a clear.
+      if (isFinite(root.pendingLatitude)
+          && root.pendingLatitude === root.homeLatitude
+          && root.pendingLongitude === root.homeLongitude) root.recenter()
+
+      // Then ask the service to re-read rather than waiting for its file watch.
+      // The first location ever written lands in a directory that did not exist
+      // when that watch was set up, so nothing would announce it. A different
+      // city arrives asynchronously and recentres again.
       if (root.radar && root.radar.reloadLocation) root.radar.reloadLocation()
 
-      // Recentre on whatever arrives from the file rather than on what was
-      // typed, so the map always agrees with what was stored.
-      root.panned = false
       root.cancelEditingLocation()
     }
   }
-
-  // Recentre whenever the stored location changes, including when it was
-  // changed from the stock weather widget rather than from here.
-  onHomeLatitudeChanged: if (!panned) recenter()
-  onHomeLongitudeChanged: if (!panned) recenter()
 
   // ---------------------------------------------------------------------------
   // Frames
@@ -353,6 +402,14 @@ Panel {
   }
 
   property bool manifestHeld: false
+
+  // A bar surface is rebuilt per monitor, so a panel can be destroyed while it
+  // still holds the manifest — unplugging a screen with the map open. Without
+  // this the refcount never comes back down and the service keeps fetching
+  // frames for a panel nobody has.
+  Component.onDestruction: {
+    if (manifestHeld && root.radar && root.radar.releaseManifest) root.radar.releaseManifest()
+  }
 
   function onOpened() {
     if (!panned && hasLocation) recenter()

--- a/Panel.qml
+++ b/Panel.qml
@@ -234,9 +234,14 @@ Panel {
     onExited: function(exitCode) {
       root.savingLocation = false
       if (exitCode !== 0) return
-      // The service watches the file and will push the new coordinates back
-      // through `radar.location`; recentre on whatever arrives rather than on
-      // what was typed, so the map always agrees with what was stored.
+
+      // Tell the service to re-read rather than waiting for its file watch.
+      // The first location ever written lands in a directory that did not
+      // exist when that watch was set up, so nothing would announce it.
+      if (root.radar && root.radar.reloadLocation) root.radar.reloadLocation()
+
+      // Recentre on whatever arrives from the file rather than on what was
+      // typed, so the map always agrees with what was stored.
       root.panned = false
       root.cancelEditingLocation()
     }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ standing next to a weather widget supplies the rest. `--section` takes `left`,
 rewrites the widget's entry, so move it before tuning the settings rather than
 after.
 
+### Updating
+
+```bash
+omarchy plugin update eduardodallecort.weather-radar
+omarchy restart shell
+```
+
+The restart is not optional. `omarchy plugin update` fetches the new code and
+asks the shell to rescan, but an already-mounted service is not rebuilt from
+it — the shell logs that it reloaded the plugin while continuing to run the
+version it started with. Until the shell restarts, an update has changed the
+files on disk and nothing else.
+
 ### Removing it
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ standing next to a weather widget supplies the rest. `--section` takes `left`,
 rewrites the widget's entry, so move it before tuning the settings rather than
 after.
 
+If that second command reports the plugin is unknown, run it again. Installing
+asks the shell to rescan and returns before the shell has finished indexing the
+new directory, so a command issued immediately afterwards can arrive first.
+
 ### Updating
 
 ```bash

--- a/RadarModel.js
+++ b/RadarModel.js
@@ -267,10 +267,12 @@ var SAMPLE_RADIUS_KM = 5
 // travel in a single request, so the extra coverage costs a larger response
 // rather than more requests.
 function samplePoints(lat, lon, km) {
-  // Coerce first: a caller holding an unset location would otherwise produce
-  // points carrying null, which only fails later and further away.
-  lat = Number(lat)
-  lon = Number(lon)
+  // parseFloat rather than Number, because an unset location carries null and
+  // Number(null) is 0 — a guard built on it would admit the exact case it
+  // exists to reject and place the caller off the coast of west Africa.
+  // parseFloat(null) and parseFloat("") are both NaN, which is what is meant.
+  lat = parseFloat(lat)
+  lon = parseFloat(lon)
   if (!isFinite(lat) || !isFinite(lon)) return []
 
   var radius = km || SAMPLE_RADIUS_KM

--- a/RadarModel.js
+++ b/RadarModel.js
@@ -267,6 +267,12 @@ var SAMPLE_RADIUS_KM = 5
 // travel in a single request, so the extra coverage costs a larger response
 // rather than more requests.
 function samplePoints(lat, lon, km) {
+  // Coerce first: a caller holding an unset location would otherwise produce
+  // points carrying null, which only fails later and further away.
+  lat = Number(lat)
+  lon = Number(lon)
+  if (!isFinite(lat) || !isFinite(lon)) return []
+
   var radius = km || SAMPLE_RADIUS_KM
   var dLat = radius / 111.32
   // Longitude degrees shrink towards the poles; without the cosine the

--- a/Service.qml
+++ b/Service.qml
@@ -96,11 +96,18 @@ Item {
   }
 
   // Covers the same gap for a file written by something else — the stock
-  // weather widget, or `omarchy-weather-location` run in a terminal. Retries
-  // only while no location is known, and stops for good once one is.
+  // weather widget, or `omarchy-weather-location` run in a terminal. Runs only
+  // while no location is known and stops for good once one is.
+  //
+  // Having no location is not necessarily brief: clearing it from this panel
+  // removes the file, and committing a typed name with no suggestion chosen
+  // stores a name without coordinates, which is deliberately read as no
+  // location. Either can last a session, and each tick rebuilds the file
+  // watcher as well as reading, so it slows down when nobody is looking at the
+  // map — five seconds while the panel is open, a minute otherwise.
   Timer {
-    interval: root.hasLocation ? 1500 : 5000
-    repeat: !root.hasLocation
+    interval: root.frameConsumers > 0 ? 5000 : 60000
+    repeat: true
     running: !root.hasLocation
     triggeredOnStart: true
     onTriggered: locationFile.reload()
@@ -299,10 +306,14 @@ Item {
     // Read the coordinates once and confirm they are numbers before building a
     // request out of them. `hasLocation` is derived from a property that other
     // code reassigns, and a plugin reload landing between the two has been seen
-    // to reach this with nulls; a request built from those would throw rather
-    // than fail.
-    var lat = Number(location.latitude)
-    var lon = Number(location.longitude)
+    // to reach this with nulls.
+    //
+    // parseFloat, not Number: an unset location carries null, Number(null) is
+    // 0, and a request built from that would quietly report the weather at
+    // 0°N 0°E — an alert naming no city, about an ocean. Failing loudly beats
+    // answering confidently about the wrong hemisphere.
+    var lat = parseFloat(location.latitude)
+    var lon = parseFloat(location.longitude)
     if (!isFinite(lat) || !isFinite(lon)) return
 
     checking = true

--- a/Service.qml
+++ b/Service.qml
@@ -68,6 +68,11 @@ Item {
 
   // Shared with the stock weather widget, which owns the file. Watching it
   // means changing city through the Omarchy menu re-centres the radar live.
+  //
+  // The watch only reaches as far as the containing directory. On a machine
+  // where no weather location was ever set, `~/.local/state/omarchy/settings/`
+  // does not exist, so there is nothing to watch and the file appearing later
+  // is invisible — hence reloadLocation() below and the retry beneath it.
   property var location: ({ name: "", latitude: null, longitude: null, valid: false })
 
   readonly property bool hasLocation: location && location.valid === true
@@ -83,11 +88,21 @@ Item {
     onLoadFailed: root.location = RadarModel.parseLocationFile("")
   }
 
-  // The first read can race shell startup. One delayed reload self-corrects,
-  // and is a no-op when the first read already succeeded.
+  // Re-read the file now rather than waiting to be told about it. Whoever
+  // writes the location calls this immediately afterwards, which is the only
+  // way the first one to exist is ever noticed.
+  function reloadLocation() {
+    locationFile.reload()
+  }
+
+  // Covers the same gap for a file written by something else — the stock
+  // weather widget, or `omarchy-weather-location` run in a terminal. Retries
+  // only while no location is known, and stops for good once one is.
   Timer {
-    interval: 1500
-    running: true
+    interval: root.hasLocation ? 1500 : 5000
+    repeat: !root.hasLocation
+    running: !root.hasLocation
+    triggeredOnStart: true
     onTriggered: locationFile.reload()
   }
 
@@ -280,13 +295,30 @@ Item {
 
   function checkNow() {
     if (!hasLocation || checking) return
+
+    // Read the coordinates once and confirm they are numbers before building a
+    // request out of them. `hasLocation` is derived from a property that other
+    // code reassigns, and a plugin reload landing between the two has been seen
+    // to reach this with nulls; a request built from those would throw rather
+    // than fail.
+    var lat = Number(location.latitude)
+    var lon = Number(location.longitude)
+    if (!isFinite(lat) || !isFinite(lon)) return
+
     checking = true
 
     // Five coordinates rather than one: the centre and four points 5 km out.
     // See RadarModel.samplePoints — the model grid is coarse enough that a
     // stored coordinate speaks for an arbitrary patch beside it rather than
     // for the town it names. They all travel in one request.
-    var points = RadarModel.samplePoints(location.latitude, location.longitude)
+    var points = RadarModel.samplePoints(lat, lon)
+    if (points.length === 0) {
+      // Unreachable given the check above, but a guard that returns without
+      // clearing `checking` would block every later check for the session.
+      checking = false
+      return
+    }
+
     var lats = []
     var lons = []
     for (var i = 0; i < points.length; i++) {

--- a/Service.qml
+++ b/Service.qml
@@ -95,22 +95,32 @@ Item {
     locationFile.reload()
   }
 
-  // Covers the same gap for a file written by something else — the stock
-  // weather widget, or `omarchy-weather-location` run in a terminal. Runs only
-  // while no location is known and stops for good once one is.
+  // Covers the one window the file watch cannot: before any location has ever
+  // been stored the settings directory does not exist, so a file created in it
+  // is invisible. Once the directory exists the watch works — clearing a
+  // location only removes the file — so what is needed is a bridge across the
+  // start of the very first session, not a permanent watchdog.
   //
-  // Having no location is not necessarily brief: clearing it from this panel
-  // removes the file, and committing a typed name with no suggestion chosen
-  // stores a name without coordinates, which is deliberately read as no
-  // location. Either can last a session, and each tick rebuilds the file
-  // watcher as well as reading, so it slows down when nobody is looking at the
-  // map — five seconds while the panel is open, a minute otherwise.
+  // It runs quickly at first and then slowly forever, rather than stopping.
+  // Stopping would strand the machine it exists for: with no directory to
+  // watch, a location chosen an hour later from the stock weather widget or a
+  // terminal would never be seen, while that widget updated live. A read a
+  // minute apart is a file stat, and the burst is never re-armed, because
+  // being without a location is otherwise an ordinary long-lived state —
+  // clearing it from the panel, or storing a typed name with no coordinates —
+  // and re-entering it should not restart rapid polling.
+  property int locationRetries: 0
+  readonly property int locationRetryBurst: 24
+
   Timer {
-    interval: root.frameConsumers > 0 ? 5000 : 60000
+    interval: root.locationRetries < root.locationRetryBurst ? 5000 : 60000
     repeat: true
     running: !root.hasLocation
     triggeredOnStart: true
-    onTriggered: locationFile.reload()
+    onTriggered: {
+      if (root.locationRetries < root.locationRetryBurst) root.locationRetries++
+      locationFile.reload()
+    }
   }
 
   // Identity of the configured place, and the thing "changed" is measured

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "eduardodallecort.weather-radar",
   "name": "Weather Radar",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Eduardo Dalle Cort",
   "license": "MIT",
   "description": "Live weather radar map in the Omarchy bar, with optional storm alerts for your location.",


### PR DESCRIPTION
Fixes #1.

Choosing a city did nothing until the shell was restarted.

The location is read through a `FileView` watching
`~/.local/state/omarchy/settings/weather.json`, and that watch reaches only as
far as the containing directory. On a machine where no weather location was
ever set, that directory does not exist — nothing but the two stock weather
commands ever writes there — so there is nothing to watch and the file
appearing later is invisible. Restarting works because by then the directory
exists and the file is simply read at startup.

That is the ordinary state of a fresh Omarchy install, which left the plugin's
very first interaction broken for anyone who had not already set a location for
the stock weather widget.

## Reproduced before and after

On a machine with the plugin removed and `~/.local/state/omarchy/settings/`
deleted, installing the published version and picking a city fails exactly as
reported, and a shell restart fixes it. Repeating from the same clean state
with this branch works immediately, without a restart.

## The fix

Two paths, because either alone leaves a gap:

- Whoever writes the location tells the service to re-read straight away, which
  is what the first-party weather panel does for this same reason. `reload()`
  rebuilds the file watcher as well as re-reading, so this also repairs the
  watch for everything that follows.
- The service polls while it has no location, quickly for the first two minutes
  and then once a minute for as long as that lasts. It does not stop, because
  stopping would strand the machine this exists for: a location chosen an hour
  into the session from the stock weather widget would never be seen. The fast
  burst is never re-armed, since being without a location is otherwise an
  ordinary long-lived state.

## Also in this branch

Defects found while testing the paths above, all in code this branch touches:

- Coordinates are rejected with `parseFloat` rather than `Number`. `Number(null)`
  is `0`, so a guard built on it admitted an unset location and would have
  issued a forecast request for 0°N 0°E — an alert naming no city, describing
  an ocean.
- The home coordinates are held rather than bound. A binding must yield a
  number, and `location` is reassigned a moment before `hasLocation` catches up,
  so any binding across that gap put the home marker and its alert rings off the
  coast of west Africa.
- The panel releases the frame manifest when destroyed, not only when closed. A
  panel destroyed while open — unplugging a monitor carrying it — leaked the
  refcount for the life of the shell.

## Updating

Ships as 0.1.1. Existing installs pick it up with:

```bash
omarchy plugin update eduardodallecort.weather-radar
omarchy restart shell
```

The restart is required and is easy to miss. `omarchy plugin update` fetches
the new code and asks the shell to rescan, and the shell even logs that it
reloaded the plugin — but an already-mounted service is not rebuilt and carries
on running the version it started with. This fix lives in the service, so
without the restart an update changes the files on disk and nothing else. Now
documented in the README.
