### PR TITLE
Refresh radar frames while the map is open

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -99,8 +99,8 @@ BarWidget {
     id: button
     anchors.fill: parent
     bar: root.bar
-    // The label is only meaningful while the service polls; without alerts on
-    // there is nothing fresh to report, so the icon stands alone.
+    // The label prints the alert's own outlook, so with alerts off there is
+    // nothing for it to say and the icon stands alone.
     text: root.showLabel && root.summary !== "" ? root.icon + "  " + root.summary : root.icon
     foreground: root.iconColor
     slotSize: Style.bar.statusSlot

--- a/README.md
+++ b/README.md
@@ -168,10 +168,11 @@ over the Sahel, the Amazon, the United States, Indonesia and India. Heavy lands
 near the 99th percentile of wet slots in that survey: rare enough to mean
 something, common enough to fire.
 
-The promotion rule is the one that matters for storms. An already-rainy slot is
-raised one band when CAPE reaches 2000 J/kg, or 1000 J/kg alongside gusts of
-45 km/h. Rain alone does not make weather severe — rain arriving into an
-unstable airmass does, and CAPE measures the energy available to it.
+The promotion rule is the one that matters for storms. A slot already at
+moderate or above is raised one band when CAPE reaches 2000 J/kg, or 1000 J/kg
+alongside gusts of 45 km/h. Rain alone does not make weather severe — rain
+arriving into an unstable airmass does, and CAPE measures the energy available
+to it.
 
 A severe alert names the figures that put it there, and only those: rain heavy
 enough on its own reads "up to 18 mm/h", while ordinary rain into a loaded

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ configuration outside the widget's own entry is written.
 | `Home` | recentre on your location |
 | `Esc` | close |
 
+While it is open the map looks for a new frame every ten minutes, which is about
+how often RainViewer publishes one — so the newest frame on screen can be up to
+a cycle behind theirs. Once you close it, the map asks for nothing.
+
 ### What the colours mean
 
 ![Radar over Oklahoma and Texas: blue for light rain grading through yellow and orange to red and magenta cores, over a dark base map](screenshots/map.webp)
@@ -140,10 +144,10 @@ beside each suggestion separates them from their namesakes elsewhere.
 Alerts are **off by default**. Turn them on from the toggle in the panel, or in
 the widget settings.
 
-While on, the plugin checks the forecast every ten minutes — the rate the radar
-publishes new frames, so checking more often would re-fetch bytes that have not
-changed. That is roughly 11 MB a month. With alerts off it makes no background
-requests at all, and fetches only while the map is open.
+While on, the plugin checks the forecast every ten minutes — the forecast model
+does not update any faster, so checking more often would re-fetch bytes that
+have not changed. That is roughly 15 MB a month. With alerts off it makes no
+background requests at all, and fetches only while the map is open.
 
 Two settings shape what reaches you, and they answer different questions. The
 **radius** decides how far ahead to look; the **threshold** decides how bad it

--- a/Service.qml
+++ b/Service.qml
@@ -11,11 +11,12 @@ import "RadarModel.js" as RadarModel
 //
 // Two responsibilities:
 //
-//   1. Own the RainViewer frame manifest, so opening the map does not start
-//      from nothing. It is 818 bytes and is only refreshed while something
-//      actually needs it. The property is `radarManifest` rather than the
-//      obvious `manifest` because the shell assigns the plugin's own
-//      manifest.json to any service exposing a property by that name.
+//   1. Own the RainViewer frame manifest, so that a two-monitor setup showing
+//      the map on both shares one copy instead of fetching one each. It is 818
+//      bytes, and is fetched only while the map is open. The property is
+//      `radarManifest` rather than the obvious `manifest` because the shell
+//      assigns the plugin's own manifest.json to any service exposing a
+//      property by that name.
 //
 //   2. Decide whether to warn about approaching weather, and say so once.
 //
@@ -176,19 +177,59 @@ Item {
     return frame ? frame.time : 0
   }
 
-  // The map calls this while it is open. Refcounted rather than boolean so two
-  // monitors showing the panel do not fight over whether polling should stop.
+  // Whether the newest frame in hand is one RainViewer could still improve on.
+  // Frames publish about every ten minutes, so one younger than that is the
+  // newest that exists, and asking again would return the same bytes.
+  //
+  // A function rather than a property: the answer depends on the passing of
+  // time, and a binding would only be recomputed when the manifest changed —
+  // freezing it at "current" for exactly as long as it stayed out of date.
+  //
+  // A frame that reads as newer than now means the clock moved backwards, not
+  // that RainViewer published into the future: an RTC kept in local time, or
+  // NTP correcting a drift. Freshness cannot be judged against a clock that
+  // just jumped, so the safe answer is to go and ask.
+  function manifestIsCurrent() {
+    if (!radarManifest) return false
+    var age = Date.now() / 1000 - latestFrameTime
+    return age >= 0 && age < RadarModel.FRAME_INTERVAL_SEC
+  }
+
+  // The map calls these while it is open. Refcounted rather than boolean so two
+  // monitors showing the panel do not fight over whether fetching should stop.
   function acquireManifest() {
     frameConsumers++
-    if (!radarManifest) refreshManifest()
+    refreshManifest()
   }
 
   function releaseManifest() {
     frameConsumers = Math.max(0, frameConsumers - 1)
   }
 
+  // Every request passes through here, so this is where "is it worth asking"
+  // belongs, rather than at each call site. Three reasons not to: one is
+  // already in flight, the frames in hand are already the newest published, or
+  // the last attempt was too recent to have changed anything.
+  readonly property int minFetchGapMs: 60000
+  property real lastManifestFetchMs: 0
+
   function refreshManifest() {
     if (manifestProc.running) return
+    if (manifestIsCurrent()) return
+
+    var now = Date.now()
+    // As above, in the other direction: a request stamped in the future is a
+    // clock that moved, and left alone it would refuse every fetch until real
+    // time caught up — hours, on a machine whose RTC was wrong.
+    if (lastManifestFetchMs > now) lastManifestFetchMs = 0
+
+    // The floor bounds what opening and closing the map repeatedly can cost,
+    // so it guards frames already on screen and waits until there are some.
+    // Someone watching an empty map who closes it and opens it again is asking
+    // to retry, and a minute of silence is not an answer to that.
+    if (radarManifest && lastManifestFetchMs > 0 && now - lastManifestFetchMs < minFetchGapMs) return
+
+    lastManifestFetchMs = now
     manifestProc.command = ["curl", "-fsS", "--max-time", "10", RadarModel.MANIFEST_URL]
     manifestProc.running = true
   }
@@ -613,16 +654,30 @@ Item {
   readonly property int baseIntervalMs: RadarModel.FRAME_INTERVAL_SEC * 1000
   readonly property int backoffMultiplier: Math.min(6, Math.pow(2, Math.min(consecutiveFailures, 3)))
 
+  // Two things want this cadence, and either one on its own is reason enough to
+  // run: the alert check, which needs a location, and the map, which needs to
+  // be open.
+  //
+  // The backoff belongs to the alert check alone, because only the forecast can
+  // raise it, and it stands down while the map is open. Nothing about
+  // api.open-meteo.com refusing — a rate limit, a bad DNS answer, an outage of
+  // that one host — says anything about RainViewer, and stretching the map's
+  // cadence to an hour on that evidence would freeze the picture in front of
+  // someone who is watching it. With nobody watching, an hour between attempts
+  // is the right courtesy to a service having a bad day.
   Timer {
     id: pollTimer
-    interval: root.baseIntervalMs * root.backoffMultiplier
+    readonly property bool alerting: root.alertsEnabled && root.hasLocation
+    readonly property bool watched: root.frameConsumers > 0
+    interval: root.baseIntervalMs * (alerting && !watched ? root.backoffMultiplier : 1)
     repeat: true
-    running: root.alertsEnabled && root.hasLocation
+    running: alerting || watched
     triggeredOnStart: true
     onTriggered: {
-      root.checkNow()
-      // The map wants fresh frames too, but only while someone is looking.
-      if (root.frameConsumers > 0 || root.alertsEnabled) root.refreshManifest()
+      if (alerting) root.checkNow()
+      // Frames serve the map and nothing else, so a closed map is not a reason
+      // to fetch them — including for the alert, which reads the forecast.
+      if (watched) root.refreshManifest()
     }
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "eduardodallecort.weather-radar",
   "name": "Weather Radar",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Eduardo Dalle Cort",
   "license": "MIT",
   "description": "Live weather radar map in the Omarchy bar, with optional storm alerts for your location.",

--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,7 @@
         "type": "boolean",
         "label": "Storm alerts",
         "defaultValue": false,
-        "description": "Notify when precipitation is detected within the alert radius. Also toggleable from the panel."
+        "description": "Notify when rain or a storm is forecast to reach you from within the alert radius. Also toggleable from the panel."
       },
       {
         "key": "alertRadiusKm",
@@ -54,7 +54,7 @@
         "label": "Alert threshold",
         "options": ["Light", "Moderate", "Heavy", "Severe"],
         "defaultValue": "Heavy",
-        "description": "Minimum echo intensity worth a notification."
+        "description": "Minimum forecast rain rate worth a notification. Moderate or heavier arriving into an unstable airmass counts one band up, so a storm crosses the threshold sooner than steady rain of the same rate."
       },
       {
         "key": "colorScheme",
@@ -102,7 +102,7 @@
         "type": "boolean",
         "label": "Show status text in bar",
         "defaultValue": false,
-        "description": "Print the nearest echo next to the bar icon. Requires storm alerts to be on, since that is what polls."
+        "description": "Print the outlook next to the bar icon: what is approaching, and when. Requires storm alerts to be on, since what it prints is their forecast."
       }
     ]
   }


### PR DESCRIPTION
Fixes #3.

## The bug

The RainViewer frame manifest was refreshed only by the alert poll, whose timer ran when storm alerts were armed. With alerts off — the default — the manifest was fetched once, on the first open of the session, and never again. The map showed the same frame for the life of the shell, and reopening the panel showed that same frame, because the only thing that would have refetched was `if (!radarManifest)`, long since false.

The reporter found the workaround unaided: turning alerts on, or restarting the shell, both made it work.

There was a `frameConsumers > 0` check inside the timer's handler, written for exactly this case. It was unreachable, because the timer that would have evaluated it was not running.

## What changed

**Fetching follows the map.** The poll runs while alerts are armed *or* the map is open, and asks for frames only in the second case.

**One place decides whether a request is worth making**, so every caller gets the same answers: one is already in flight, the frames in hand are the newest published, or the last attempt was too recent. That last floor stands aside while the map is empty, so reopening a map that failed to load retries at once instead of waiting it out.

**Backoff belongs to the forecast**, the only thing that can raise it, and stands down while the map is open. An Open-Meteo rate limit or outage says nothing about RainViewer, and slowing the map to hourly on that evidence would reproduce this very bug under a different trigger.

**Clock steps are survivable.** Frame age and last-request time are read against a clock that can move backwards — an RTC kept in local time, NTP correcting a drift. A negative reading is treated as a jump, and therefore a reason to ask rather than to wait. Without this, both new guards fail closed and the map freezes for the length of the skew.

### Deliberate behaviour change

Previously, with alerts on, the manifest was fetched every ten minutes whether or not the map had ever been opened — around 144 requests a day that nothing read. Frames are now fetched only while the map is open. The cost is one request on the first open of a session; the gain is that the plugin's documented claim about what it fetches becomes true.

## Verification

Run against the live plugin with the poll interval temporarily reduced, reading the shell's own log:

- alerts off, map closed — timer stopped, no requests
- alerts off, map open — advances every interval; **this is the reported bug**
- map closed again — timer stops
- alerts on, map closed — forecast checks continue, zero frame requests
- alerts on, no location — map-only refresh, no forecast traffic
- five rapid open/close cycles — zero requests when frames are current, one when stale
- empty map, repeated reopen inside the floor — retries every time
- frame age forced negative and last-fetch stamped an hour ahead — keeps fetching, no freeze
- `consecutiveFailures` forced to 3 with alerts off — interval stays at base

Then end to end on the real cadence: opening the map picked up the newly published frame on its own.

## Also in here

The settings described an alert this plugin does not have — precipitation "detected" within the radius, a threshold on "echo intensity", a bar label printing "the nearest echo". The alert reads a point forecast and has never looked at the radar image. The promotion rule was stated as applying to rain, where the code raises only slots already at moderate or above.

Kept as a separate commit, since it was wrong before this bug existed.

The README's traffic figure was measured rather than estimated: 15 MB a month at the default radius, not 11.
