### PR TITLE
Use a cached OSM proxy for basemap tiles

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Effects
 import Quickshell
 import Quickshell.Io
 import qs.Commons
@@ -447,16 +448,18 @@ Panel {
   // Basemap
   // ---------------------------------------------------------------------------
 
-  // CARTO's label-light basemaps, picked to match the theme rather than a
-  // fixed palette: radar over a bright map in a dark theme is unreadable.
+  // OpenStreetMap's standard raster tiles need no account or API key. A local
+  // helper gives requests the provider-required identity and disk cache; it
+  // exposes only an ephemeral loopback port. A lightweight effect darkens the
+  // same tiles for dark themes so radar remains readable.
   readonly property bool darkTheme: {
     var background = Color.background
     return (0.2126 * background.r + 0.7152 * background.g + 0.0722 * background.b) < 0.5
   }
-  readonly property string basemapStyle: darkTheme ? "dark_all" : "light_all"
-
   function basemapTileUrl(z, x, y) {
-    return "https://basemaps.cartocdn.com/" + basemapStyle + "/" + z + "/" + x + "/" + y + ".png"
+    var port = radar ? Number(radar.basemapProxyPort || 0) : 0
+    if (port <= 0) return ""
+    return "http://127.0.0.1:" + port + "/" + z + "/" + x + "/" + y + ".png"
   }
 
   function radarTileUrlA(z, x, y) { return root.radarTileUrlForFrame(root.frameA, z, x, y) }
@@ -553,6 +556,14 @@ Panel {
               centerLongitude: root.viewLongitude
               zoom: root.zoom
               tileUrlFor: root.basemapTileUrl
+              revision: root.radar ? root.radar.basemapProxyPort : 0
+              layer.enabled: root.darkTheme
+              layer.smooth: true
+              layer.effect: MultiEffect {
+                brightness: -0.48
+                contrast: 0.12
+                saturation: -0.35
+              }
             }
 
             // Two radar layers that trade places. See showFrame(): the next
@@ -685,7 +696,7 @@ Panel {
               anchors.right: parent.right
               anchors.bottom: parent.bottom
               anchors.margins: Style.space(6)
-              text: "RainViewer · CARTO · OpenStreetMap"
+              text: "RainViewer · © OpenStreetMap contributors"
               color: root.bar ? root.bar.foreground : Color.foreground
               font.family: Style.font.family
               font.pixelSize: Style.font.caption * 0.8

--- a/README.md
+++ b/README.md
@@ -273,8 +273,9 @@ absolute half is what stays true for someone reading it later.
 
 - Radar imagery: [RainViewer](https://www.rainviewer.com) — best-effort, no SLA
 - Forecast and geocoding: [Open-Meteo](https://open-meteo.com)
-- Base map: [CARTO](https://carto.com/basemaps/) over
-  [OpenStreetMap](https://www.openstreetmap.org/copyright) data
+- Base map: [OpenStreetMap](https://www.openstreetmap.org/copyright), fetched
+  through a loopback-only helper that supplies the required application
+  identity and keeps a seven-day disk cache
 
 ## Roadmap
 

--- a/Service.qml
+++ b/Service.qml
@@ -55,6 +55,15 @@ Item {
   readonly property int alertRadiusKm: Math.max(25, Math.min(250, Number(setting("alertRadiusKm", 100)) || 100))
   readonly property string alertThreshold: String(setting("alertMinIntensity", "Heavy"))
 
+  // Qt Quick Image cannot add the identifying User-Agent required by the
+  // OpenStreetMap tile service. A loopback-only Python helper does that and
+  // maintains the required seven-day cache; its ephemeral port is shared with
+  // every panel instance through this singleton.
+  property int basemapProxyPort: 0
+  property int basemapProxyRestartMs: 2000
+  property bool basemapProxyStopping: false
+  readonly property string basemapProxyPath: Qt.resolvedUrl("basemap_proxy.py").toString().replace(/^file:\/\//, "")
+
   // Storms in most of the world travel somewhere around 50 km/h, so the alert
   // radius doubles as a lead time: 100 km is roughly two hours of warning.
   // Expressing it this way means one setting controls both the ring drawn on
@@ -122,6 +131,45 @@ Item {
       if (root.locationRetries < root.locationRetryBurst) root.locationRetries++
       locationFile.reload()
     }
+  }
+
+  Timer {
+    id: basemapProxyRestart
+    interval: root.basemapProxyRestartMs
+    repeat: false
+    onTriggered: basemapProxy.running = true
+  }
+
+  Process {
+    id: basemapProxy
+    command: ["python3", root.basemapProxyPath]
+    stdout: SplitParser {
+      splitMarker: "\n"
+      onRead: function(line) {
+        var match = /^READY (\d+)$/.exec(String(line || "").trim())
+        if (!match) return
+        root.basemapProxyPort = Number(match[1])
+        root.basemapProxyRestartMs = 2000
+      }
+    }
+    stderr: SplitParser {
+      splitMarker: "\n"
+      onRead: function(line) {
+        if (String(line || "").trim() !== "") console.warn("weather-radar basemap: " + line)
+      }
+    }
+    onExited: function(exitCode) {
+      root.basemapProxyPort = 0
+      if (root.basemapProxyStopping) return
+      root.basemapProxyRestartMs = Math.min(30000, root.basemapProxyRestartMs * 2)
+      basemapProxyRestart.restart()
+    }
+  }
+
+  Component.onCompleted: basemapProxy.running = true
+  Component.onDestruction: {
+    root.basemapProxyStopping = true
+    basemapProxy.running = false
   }
 
   // Identity of the configured place, and the thing "changed" is measured

--- a/basemap_proxy.py
+++ b/basemap_proxy.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Small, policy-compliant OpenStreetMap tile proxy for the QML map.
+
+Qt Quick's Image element cannot attach the identifying User-Agent required by
+OpenStreetMap's standard tile service.  This loopback-only helper adds that
+identity and keeps a seven-day disk cache; QML never talks to the tile service
+directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+UPSTREAM = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+USER_AGENT = (
+    "omarchy-weather-radar/0.1.2 "
+    "(+https://github.com/eduardodallecort/omarchy-weather-radar)"
+)
+CACHE_SECONDS = 7 * 24 * 60 * 60
+MAX_ZOOM = 19
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+TILE_PATH = re.compile(r"^/(\d+)/(\d+)/(\d+)\.png$")
+
+
+def parse_tile_path(path: str) -> tuple[int, int, int] | None:
+    match = TILE_PATH.fullmatch(path)
+    if not match:
+        return None
+    z, x, y = (int(value) for value in match.groups())
+    if z > MAX_ZOOM or x >= 2**z or y >= 2**z:
+        return None
+    return z, x, y
+
+
+class TileServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, address: tuple[str, int], cache_dir: Path):
+        super().__init__(address, TileHandler)
+        self.cache_dir = cache_dir
+        self._locks: dict[Path, threading.Lock] = {}
+        self._locks_guard = threading.Lock()
+
+    def lock_for(self, path: Path) -> threading.Lock:
+        with self._locks_guard:
+            return self._locks.setdefault(path, threading.Lock())
+
+
+class TileHandler(BaseHTTPRequestHandler):
+    server: TileServer
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        tile = parse_tile_path(self.path)
+        if tile is None:
+            self.send_error(404)
+            return
+
+        z, x, y = tile
+        cache_path = self.server.cache_dir / str(z) / str(x) / f"{y}.png"
+        try:
+            data = self._tile_bytes(cache_path, z, x, y)
+        except (OSError, urllib.error.URLError, TimeoutError):
+            self.send_error(502, "Basemap tile is temporarily unavailable")
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "image/png")
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Cache-Control", f"public, max-age={CACHE_SECONDS}")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _tile_bytes(self, path: Path, z: int, x: int, y: int) -> bytes:
+        with self.server.lock_for(path):
+            if self._fresh(path):
+                return path.read_bytes()
+
+            try:
+                data = self._download(z, x, y)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                temporary = path.with_suffix(f".tmp-{os.getpid()}-{threading.get_ident()}")
+                try:
+                    temporary.write_bytes(data)
+                    os.replace(temporary, path)
+                finally:
+                    temporary.unlink(missing_ok=True)
+                return data
+            except (OSError, urllib.error.URLError, TimeoutError):
+                # A stale map is more useful than a blank one during an outage,
+                # and serving it does not create another upstream request.
+                if path.is_file():
+                    return path.read_bytes()
+                raise
+
+    @staticmethod
+    def _fresh(path: Path) -> bool:
+        try:
+            return time.time() - path.stat().st_mtime < CACHE_SECONDS
+        except OSError:
+            return False
+
+    @staticmethod
+    def _download(z: int, x: int, y: int) -> bytes:
+        request = urllib.request.Request(
+            UPSTREAM.format(z=z, x=x, y=y),
+            headers={"User-Agent": USER_AGENT, "Accept": "image/png"},
+        )
+        with urllib.request.urlopen(request, timeout=12) as response:
+            data = response.read()
+        if not data.startswith(PNG_SIGNATURE):
+            raise OSError("upstream returned a non-PNG response")
+        return data
+
+    def log_message(self, _format: str, *args: object) -> None:
+        # Tile requests are routine and would otherwise flood the shell log.
+        pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path.home() / ".cache" / "omarchy-weather-radar" / "osm",
+    )
+    args = parser.parse_args()
+
+    server = TileServer(("127.0.0.1", 0), args.cache_dir)
+    print(f"READY {server.server_port}", flush=True)
+    try:
+        server.serve_forever(poll_interval=0.5)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- replace the CARTO basemap with standard OpenStreetMap tiles through a loopback-only helper
- supply the required application identity and maintain a seven-day disk cache
- darken the same tiles for dark themes and update the map attribution

## Testing

- compiled basemap_proxy.py in memory
- verified valid and invalid tile-path parsing
- ran git diff --check