### PR TITLE
Hold the crossfade until the incoming frame has loaded

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -548,6 +548,13 @@ Panel {
   function radarTileUrlA(z, x, y) { return root.radarTileUrlForFrame(root.frameA, z, x, y) }
   function radarTileUrlB(z, x, y) { return root.radarTileUrlForFrame(root.frameB, z, x, y) }
 
+  // Where the loop goes next, fetched a step early. Only while it is running:
+  // someone scrubbing by hand has no next frame worth guessing, and someone
+  // sitting on a still frame should not be pulling tiles at all.
+  readonly property int prefetchFrame: playing && frames.length > 1
+    ? Frames.nextIndex(frames, frameIndex) : -1
+  function radarTileUrlPrefetch(z, x, y) { return root.radarTileUrlForFrame(root.prefetchFrame, z, x, y) }
+
   // ---------------------------------------------------------------------------
   // Radar coverage
   // ---------------------------------------------------------------------------
@@ -634,6 +641,8 @@ Panel {
 
           radarTileUrlA: root.radarTileUrlA
           radarTileUrlB: root.radarTileUrlB
+          prefetchFrame: root.prefetchFrame
+          radarTileUrlPrefetch: root.radarTileUrlPrefetch
 
           frameA: root.frameA
           frameB: root.frameB

--- a/ui/RadarMap.qml
+++ b/ui/RadarMap.qml
@@ -35,12 +35,52 @@ Item {
   property var radarTileUrlA: null
   property var radarTileUrlB: null
 
+  // The frame after the one coming in, fetched into a layer nobody sees so
+  // that it is in the pixmap cache before the loop asks for it. Without it the
+  // first pass through a loop is the only one that stutters, which is still
+  // the pass someone watches with the panel newly open.
+  property int prefetchFrame: -1
+  property var radarTileUrlPrefetch: null
+
   // Which of the two radar layers holds which frame, and which is in front.
   // Bumping a layer's frame while it is behind, then swapping, is what makes
   // the loop dissolve instead of flicker.
   property int frameA: -1
   property int frameB: -1
   property bool frontIsA: true
+
+  // The swap the panel has asked for, and the one actually on screen. They
+  // differ while the incoming layer is still fetching its tiles: fading to a
+  // layer that has not arrived is what a flicker is, so the request is held
+  // until the tiles are there. Held, not dropped — a layer that never
+  // completes, because the network is down or a tile 404s past the edge of
+  // coverage, still has to give way, so the fallback below swaps regardless.
+  property bool showA: true
+  readonly property var incomingLayer: frontIsA ? radarA : radarB
+
+  // Deferred, not immediate: the frame is written into the layer behind and the
+  // swap asked for in the same pass, and read at that moment the layer still
+  // reports the tiles it held before its sources were repointed. One turn of
+  // the loop later it reports the ones it is actually fetching.
+  onFrontIsAChanged: Qt.callLater(root.applySwapWhenReady)
+
+  function applySwapWhenReady() {
+    if (showA === frontIsA) return
+    if (incomingLayer.contentReady) {
+      swapFallback.stop()
+      showA = frontIsA
+    } else if (!swapFallback.running) {
+      swapFallback.restart()
+    }
+  }
+
+  Timer {
+    id: swapFallback
+    // Shorter than the shortest playback step, so a layer that will not finish
+    // loading costs the loop a frame's worth of delay rather than stalling it.
+    interval: 500
+    onTriggered: root.showA = root.frontIsA
+  }
 
   // Changes when the frame list is replaced. Folded into each layer's revision
   // so that a new manifest reloads the tiles even when the index did not move.
@@ -100,6 +140,21 @@ Item {
       zoom: root.zoom
     }
 
+    // Fetches, draws nothing. An Image loads its source whether or not the item
+    // it belongs to is painted, which is the whole trick here.
+    TileLayer {
+      id: radarPrefetch
+      anchors.fill: parent
+      centerLatitude: root.centerLatitude
+      centerLongitude: root.centerLongitude
+      zoom: root.zoom
+      sourceZoom: root.radarSourceZoom
+      tileUrlFor: root.radarTileUrlPrefetch
+      revision: root.prefetchFrame + (root.colorSchemeId * 1000) + (root.frameEpoch * 100000)
+      smooth: root.smoothTiles
+      opacity: 0
+    }
+
     TileLayer {
       id: radarA
       anchors.fill: parent
@@ -110,7 +165,8 @@ Item {
       tileUrlFor: root.radarTileUrlA
       revision: root.frameA + (root.colorSchemeId * 1000) + (root.frameEpoch * 100000)
       smooth: root.smoothTiles
-      opacity: root.frontIsA ? 1 : 0
+      opacity: root.showA ? 1 : 0
+      onContentReadyChanged: root.applySwapWhenReady()
       Behavior on opacity {
         NumberAnimation { duration: 380; easing.type: Easing.InOutQuad }
       }
@@ -126,7 +182,8 @@ Item {
       tileUrlFor: root.radarTileUrlB
       revision: root.frameB + (root.colorSchemeId * 1000) + (root.frameEpoch * 100000)
       smooth: root.smoothTiles
-      opacity: root.frontIsA ? 0 : 1
+      opacity: !root.showA ? 1 : 0
+      onContentReadyChanged: root.applySwapWhenReady()
       Behavior on opacity {
         NumberAnimation { duration: 380; easing.type: Easing.InOutQuad }
       }

--- a/ui/TileLayer.qml
+++ b/ui/TileLayer.qml
@@ -35,8 +35,16 @@ Item {
   property var tileUrlFor: null
 
   // Bumped by the owner to force a reload when the URL scheme itself changes
-  // (a new frame, a different palette) so bindings re-evaluate.
+  // (a new frame, a different palette) so bindings re-evaluate. It is read by
+  // each tile's source binding rather than by the model below: a new frame
+  // must repoint the tiles, not tear the whole grid down and build it again.
   property int revision: 0
+
+  // Tiles still waiting on the network. Zero means every tile this layer wants
+  // is on screen, which is what lets the owner hold a crossfade back until the
+  // incoming frame is actually there to fade to.
+  property int pendingTiles: 0
+  readonly property bool contentReady: pendingTiles <= 0
 
   property int tileSize: 256
   property bool smooth: true
@@ -52,15 +60,14 @@ Item {
     centerLatitude, centerLongitude, sourceZoom,
     Math.max(1, width / sourceScale), Math.max(1, height / sourceScale))
 
-  // Flattened tile list. Rebuilt whenever the viewport moves; at the zoom
+  // Flattened tile list. Rebuilt whenever the viewport moves — but not when the
+  // frame changes, which only repoints the tiles that are already there. At the zoom
   // levels this plugin uses that is a few dozen entries, so the simple
   // approach beats an incremental one for readability.
   readonly property var tiles: {
     var list = []
     var view = layout
     if (!view || width <= 0 || height <= 0) return list
-    // `revision` is read so the model rebuilds when the frame changes.
-    var unused = revision
     var scale = sourceScale
     for (var y = view.minY; y <= view.maxY; y++) {
       if (!TileMath.isValidTileY(y, sourceZoom)) continue
@@ -87,7 +94,11 @@ Item {
       width: root.tileSize * root.sourceScale
       height: root.tileSize * root.sourceScale
 
-      source: root.tileUrlFor ? root.tileUrlFor(root.sourceZoom, modelData.tileX, modelData.tileY) : ""
+      source: {
+        // Read so a new frame or palette repoints this tile in place.
+        var unused = root.revision
+        return root.tileUrlFor ? root.tileUrlFor(root.sourceZoom, modelData.tileX, modelData.tileY) : ""
+      }
       asynchronous: true
       cache: true
       // The loader is asked for a tile-sized surface rather than whatever the
@@ -106,6 +117,15 @@ Item {
       // image rather than as an error.
       visible: status === Image.Ready
       onStatusChanged: if (status === Image.Error) root.tileFailed()
+
+      // Each tile reports only its own state, adding one to the layer's count
+      // while it is outstanding and taking it away once it settles. Counting
+      // that way survives tiles being created and destroyed under a pan
+      // without the layer ever having to recount them.
+      readonly property bool settled: source == "" || status === Image.Ready || status === Image.Error
+      onSettledChanged: root.pendingTiles += settled ? -1 : 1
+      Component.onCompleted: if (!settled) root.pendingTiles++
+      Component.onDestruction: if (!settled) root.pendingTiles--
     }
   }
 }


### PR DESCRIPTION
Playback flickers on every step: the map dips to blank and the tiles pop back
in partway through the fade. Two things put it in that state, and they compound.

**The frame index rebuilt the tile grid.** `revision` was read inside
`TileLayer`'s `tiles` binding, so a new frame destroyed every `Image` in the
layer and built it again. Each one starts `visible: status === Image.Ready`, so
the layer went blank for a frame even when every tile was already in Qt's
pixmap cache — which is exactly the case the URL-keyed cache was there to make
free. The frame now reaches the tiles through their `source` binding instead:
the grid stays put, the tiles repoint.

**The swap did not wait for the incoming frame.** `Panel.showFrame()` loads the
frame into the layer behind and flips `frontIsA` in the next statement, so the
380ms crossfade started against a layer that had nothing in it yet. Layers now
count the tiles they are still fetching (`pendingTiles`, each tile reporting
only its own state so the count survives tiles coming and going under a pan),
and `RadarMap` holds the swap until that count reaches zero.

Two details that the first version of this got wrong, both caught by driving
the layers under `qml6`:

- The readiness check has to be deferred by one turn of the event loop. The
  frame is written into the back layer and the swap requested in the same pass;
  read at that moment, the layer still reports the tiles it held *before* its
  sources were repointed, and the swap goes through against a stale count.
  `Qt.callLater` fixes it — in a six-step probe, 3 of 6 swaps were dirty before
  and none after, leaving only the deliberate fallback ones.
- A fallback timer, shorter than the shortest playback step, swaps regardless.
  Without it a tile that 404s past the edge of radar coverage, or a layer
  caught by a dropped network, stalls the loop indefinitely.

**One layer nobody sees.** With the fade honest about when it can start, the
first pass through a loop was left as the one that stutters, since nothing is
cached yet — and with the panel newly opened, that is the pass someone actually
watches. A third `TileLayer` at `opacity: 0` holds the frame after the incoming
one; an `Image` loads its source whether or not the item is painted. It is fed
`-1` unless the loop is running, so scrubbing by hand and sitting on a still
frame fetch nothing extra.

### Testing

- `node --test` — 224 passing, unchanged.
- `RadarMap.qml` loaded under `qml6` against stubbed `qs.Commons` / `qs.Ui`
  singletons, driven the way `Panel.showFrame()` drives it: the applied swap
  always catches up with the requested one, no deadlock.
- `TileLayer` readiness accounting exercised against live RainViewer tiles,
  including 404s: `pendingTiles` rises to the tile count and returns to zero,
  errors included.
- Running on my own machine (Omarchy shell, Hyprland) through several loops.

The flicker itself is temporal, so the last one is the check that matters and I
cannot show it in a screenshot — worth a look on your side before merging.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmKjwS8vM6bxagB51SfAhz
